### PR TITLE
Remove .gitignore from ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ atlassian*
 !/composer.json
 !/composer.lock
 !/README.md
+!/.gitignore


### PR DESCRIPTION
I propose to remove the .gitignore from the ignored files because this file will not be added the developer's local git AND not be installed when running a composer install. This could cause the file getting lost, since it's neither downloaded as dependency and not under version control.

Scenario:

``` shell
$ composer create-project magento/project-community-edition PROJECT_DIR 1.0.0-beta
$ cd PROJECT_DIR
$ git init
$ git status
On branch master

Initial commit

Untracked files:
  (use "git add <file>..." to include in what will be committed)

    README.md
    composer.json
    composer.lock
```
